### PR TITLE
fix_parsing_tarball

### DIFF
--- a/resources/runassociationtesting/ingest_data.py
+++ b/resources/runassociationtesting/ingest_data.py
@@ -94,7 +94,7 @@ class IngestData:
             tarball_name = dxtarballs.describe()['name']
             dxpy.download_dxfile(dxtarballs, tarball_name)
             if tarfile.is_tarfile(tarball_name):
-                tarball_prefix = tarball_name.rstrip('.tar.gz')
+                tarball_prefix = tarball_name.replace(".tar.gz", "")
                 self.tarball_prefixes.append(tarball_prefix)
                 tar = tarfile.open(tarball_name, "r:gz")
                 tar.extractall()


### PR DESCRIPTION
I have made a small change in how the names of the tarballs from collapsevariants are parsed in `ingest_data.py `. The function `rstrip` was replaced with `replace`.

This was done because strip() method in python will remove any character at beginning/end of the string that matches the set of characters we provided for removal. Behaviour is described for example here https://stackoverflow.com/questions/23669024/how-to-strip-a-specific-word-from-a-string.

I have tested this fix by rebuilding runassocationtesting as an applet (applet-GFFK87jJZGXP9qG81qfB5F5Z) and using a prefix **"14_07_collapse_34genes_stasa"**  that would have thrown an error before because "a" is part of "tar.gz".  (job-GFFK9fjJZGXBq0Qk3bq5jfkx) Now the program runs as expected with the output that previously threw an error.
